### PR TITLE
🖼️ Correction de l'affichage des avatars sur la page communauté

### DIFF
--- a/app/Http/Controllers/CountryController.php
+++ b/app/Http/Controllers/CountryController.php
@@ -119,7 +119,7 @@ class CountryController extends Controller
         
         // Get community members from this country with optimized pagination
         $communityMembers = User::where('country_residence', $countryModel->name_fr)
-            ->select(['id', 'name', 'is_verified', 'role', 'city_residence', 'bio', 'created_at'])
+            ->select(['id', 'name', 'avatar', 'is_verified', 'role', 'city_residence', 'bio', 'created_at'])
             ->paginate(12);
         
         return view('country.communaute', compact('countryModel', 'communityMembers'));

--- a/resources/views/country/communaute.blade.php
+++ b/resources/views/country/communaute.blade.php
@@ -46,9 +46,13 @@
                                 <!-- Profile Header -->
                                 <div class="bg-gradient-to-r from-blue-500 to-purple-600 h-24 relative">
                                     <div class="absolute -bottom-8 left-6">
-                                        <div class="w-16 h-16 bg-white rounded-full flex items-center justify-center text-2xl font-bold text-blue-600 shadow-lg border-4 border-white">
-                                            {{ strtoupper(substr($member->name, 0, 1)) }}
-                                        </div>
+                                        @if($member->avatar)
+                                            <img src="{{ $member->getAvatarUrl() }}" alt="{{ $member->name }}" class="w-16 h-16 rounded-full shadow-lg border-4 border-white object-cover">
+                                        @else
+                                            <div class="w-16 h-16 bg-white rounded-full flex items-center justify-center text-2xl font-bold text-blue-600 shadow-lg border-4 border-white">
+                                                {{ strtoupper(substr($member->name, 0, 1)) }}
+                                            </div>
+                                        @endif
                                     </div>
                                     <!-- Role Badge -->
                                     @if($member->role !== 'free')


### PR DESCRIPTION
## Summary
• Correction du problème d'affichage des avatars sur `/thailande/communaute` 
• Ajout du champ `avatar` manquant dans la requête du controller
• Mise à jour du template pour afficher les vraies images d'avatar avec fallback

## Changes Made
• **CountryController**: Ajout du champ `avatar` à la requête `select()` dans `communaute()`
• **Template**: Logique conditionnelle pour afficher avatar ou initiales
• **Fallback**: Utilisation de `getAvatarUrl()` avec fallback vers service placeholder

## Test Plan
- [x] Vérifier que les avatars s'affichent correctement sur la page communauté
- [x] Vérifier que les initiales s'affichent pour les utilisateurs sans avatar
- [x] Tester la cohérence avec les autres pages (profils, articles, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)