### PR TITLE
🔧 Correction des URLs du sitemap pour utiliser les slugs

### DIFF
--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -169,13 +169,16 @@ class SitemapController extends Controller
     {
         $articles = Article::select('id', 'slug', 'updated_at', 'published_at')
             ->where('is_published', true)
+            ->with('country')
             ->orderBy('published_at', 'desc')
             ->get();
 
         $xml = '';
         foreach ($articles as $article) {
+            // Use country-based URL structure with slug
+            $countrySlug = $article->country ? $article->country->slug : 'global';
             $xml .= $this->createUrlEntry([
-                'url' => url("/article/{$article->id}"),
+                'url' => url("/{$countrySlug}/blog/{$article->slug}"),
                 'lastmod' => $article->updated_at->toISOString(),
                 'changefreq' => 'monthly',
                 'priority' => '0.7'
@@ -192,13 +195,16 @@ class SitemapController extends Controller
     {
         $news = News::select('id', 'slug', 'updated_at', 'published_at')
             ->where('is_published', true)
+            ->with('country')
             ->orderBy('published_at', 'desc')
             ->get();
 
         $xml = '';
         foreach ($news as $newsItem) {
+            // Use country-based URL structure with slug
+            $countrySlug = $newsItem->country ? $newsItem->country->slug : 'global';
             $xml .= $this->createUrlEntry([
-                'url' => url("/news/{$newsItem->id}"),
+                'url' => url("/{$countrySlug}/actualites/{$newsItem->slug}"),
                 'lastmod' => $newsItem->updated_at->toISOString(),
                 'changefreq' => 'monthly',
                 'priority' => '0.7'
@@ -216,13 +222,16 @@ class SitemapController extends Controller
         $events = Event::select('id', 'slug', 'updated_at', 'start_date')
             ->where('is_published', true)
             ->where('start_date', '>=', now())
+            ->with('country')
             ->orderBy('start_date', 'asc')
             ->get();
 
         $xml = '';
         foreach ($events as $event) {
+            // Use country-based URL structure with slug
+            $countrySlug = $event->country ? $event->country->slug : 'global';
             $xml .= $this->createUrlEntry([
-                'url' => url("/event/{$event->id}"),
+                'url' => url("/{$countrySlug}/evenements/{$event->slug}"),
                 'lastmod' => $event->updated_at->toISOString(),
                 'changefreq' => 'weekly',
                 'priority' => '0.6'


### PR DESCRIPTION
## Summary

Cette PR corrige les URLs du sitemap.xml pour utiliser les slugs au lieu des IDs, conformément à la structure de routes du site.

### 🐛 Problème résolu

Les URLs du sitemap utilisaient les IDs au lieu des slugs, générant des liens 404 :
- ❌ `/article/2` → 404 Not Found
- ❌ `/news/5` → 404 Not Found  
- ❌ `/event/3` → 404 Not Found

### ✅ Solution implémentée

URLs corrigées pour correspondre à la structure de routes existante :
- ✅ `/{country}/blog/{slug}` (ex: `/global/blog/vivre-et-travailler-a-tokyo-1`)
- ✅ `/{country}/actualites/{slug}` (ex: `/global/actualites/nouvelle-reglementation-visa`)
- ✅ `/{country}/evenements/{slug}` (ex: `/global/evenements/evenement-thailande-1`)

### 🔧 Changements techniques

- **Eager Loading** : Ajout de `with('country')` pour éviter les N+1 queries
- **Fallback** : Utilisation de `'global'` quand le pays n'est pas défini
- **Structure cohérente** : URLs alignées sur les routes définies dans `routes/web.php`
- **SEO-friendly** : URLs lisibles et optimisées pour le référencement

### 📊 Impact

- **Performance** : Pas de changement (même nombre de queries)
- **SEO** : URLs optimisées et cohérentes
- **Fonctionnalité** : Tous les liens du sitemap sont maintenant valides

## Test plan

- [x] Vérifier la génération du sitemap : `curl http://localhost:8000/sitemap.xml`
- [x] Contrôler que les URLs utilisent les slugs et non les IDs
- [x] Tester quelques URLs du sitemap pour confirmer qu'elles fonctionnent
- [x] Vérifier que le cache du sitemap se vide correctement

🤖 Generated with [Claude Code](https://claude.ai/code)