### PR TITLE
🐛 Fix actualités non visibles en production

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -61,7 +61,9 @@ class Article extends Model
      */
     public function scopePublished($query)
     {
-        return $query->where('is_published', true);
+        return $query->where('is_published', true)
+                     ->whereNotNull('published_at')
+                     ->where('published_at', '<=', now());
     }
 
     /**

--- a/app/Models/News.php
+++ b/app/Models/News.php
@@ -51,7 +51,9 @@ class News extends Model
      */
     public function scopePublished($query)
     {
-        return $query->where('is_published', true);
+        return $query->where('is_published', true)
+                     ->whereNotNull('published_at')
+                     ->where('published_at', '<=', now());
     }
 
     /**

--- a/database/migrations/2025_07_11_085838_fix_published_at_for_published_content.php
+++ b/database/migrations/2025_07_11_085838_fix_published_at_for_published_content.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Fix news with is_published = true but published_at = null
+        DB::table('news')
+            ->where('is_published', true)
+            ->whereNull('published_at')
+            ->update(['published_at' => now()]);
+            
+        // Fix articles with is_published = true but published_at = null
+        DB::table('articles')
+            ->where('is_published', true)
+            ->whereNull('published_at')
+            ->update(['published_at' => now()]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // We cannot reliably reverse this migration
+        // as we don't know which records had null published_at originally
+    }
+};


### PR DESCRIPTION
## Problème
Les actualités n'apparaissaient pas en production même si elles étaient marquées comme publiées (`is_published = true`).

## Cause
Le scope `published()` ne vérifiait que `is_published = true` mais pas la date de publication. Certaines actualités avaient `published_at = null`, ce qui causait des erreurs lors de l'affichage avec `->diffForHumans()`.

## Solution
1. **Modification des scopes `published()`** dans News et Article :
   - Ajout de `whereNotNull('published_at')`
   - Ajout de `where('published_at', '<=', now())`
   - Garantit qu'une actualité/article est visible seulement si elle a une date de publication valide

2. **Migration de correction des données** :
   - Corrige les actualités/articles existants avec `is_published = true` mais `published_at = null`
   - Leur assigne la date actuelle comme date de publication

3. **Cohérence** :
   - Appliqué aux modèles News et Article pour uniformité
   - Le contrôleur admin définit déjà correctement `published_at` lors de la publication

## Test
- Les actualités avec `is_published = true` ET `published_at` défini s'affichent
- Les actualités avec `published_at = null` ne s'affichent pas
- Pas d'erreur sur `->diffForHumans()` car toutes les actualités affichées ont une date

## Impact
- ✅ Résout le problème d'actualités invisibles en production
- ✅ Évite les erreurs PHP sur les dates nulles
- ✅ Cohérence avec le comportement attendu d'un système de publication

🤖 Generated with [Claude Code](https://claude.ai/code)