### PR TITLE
🔧 Convert Claude code review workflow to manual-only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,23 +1,26 @@
-name: Claude Code Review
+name: Claude Code Review (Manual)
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Numéro de la PR à reviewer'
+        required: true
+        type: string
+      review_focus:
+        description: 'Focus de la review'
+        required: false
+        default: 'Code quality, security, and best practices'
+        type: choice
+        options:
+        - 'Code quality, security, and best practices'
+        - 'Performance and optimization'
+        - 'Security and vulnerability assessment'
+        - 'Architecture and design patterns'
+        - 'Laravel best practices'
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,7 +32,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
+          
+      - name: Checkout PR
+        run: |
+          gh pr checkout ${{ github.event.inputs.pr_number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Claude Code Review
         id: claude-review
@@ -37,37 +46,53 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Use Claude Sonnet 4 for code review
+          model: "claude-sonnet-4-20250514"
           
-          # Direct prompt for automated review (no @claude mention needed)
+          # Customized prompt based on user input
           direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
+            🔍 **Code Review Request - PR #${{ github.event.inputs.pr_number }}**
             
-            Be constructive and helpful in your feedback.
+            Focus: **${{ github.event.inputs.review_focus }}**
+            
+            Please provide a comprehensive code review focusing on the selected area above. 
+            
+            For this Laravel application, please specifically check:
+            
+            **Security & Best Practices:**
+            - SQL injection vulnerabilities and proper use of Eloquent ORM
+            - XSS prevention and proper data sanitization
+            - CSRF protection implementation
+            - Authentication and authorization logic
+            - Input validation and form requests
+            - Proper use of Laravel's security features
+            
+            **Code Quality:**
+            - Laravel conventions and best practices
+            - Proper MVC architecture implementation
+            - Resource usage efficiency
+            - Error handling and exception management
+            - Code readability and maintainability
+            
+            **Performance:**
+            - Database query optimization (N+1 problems)
+            - Proper use of eager loading
+            - Caching strategies
+            - Asset optimization
+            
+            **Architecture:**
+            - Service layer implementation
+            - Dependency injection usage
+            - Event and listener patterns
+            - Job queue implementation
+            
+            ⚠️ **Important:** 
+            - Only provide review comments - DO NOT create or suggest creating any pull requests
+            - Be constructive and provide specific suggestions for improvement
+            - Focus on the selected review area while maintaining overall code quality standards
+            - Highlight any critical security or performance issues
+            
+            This is a manual review requested by the maintainer.
           
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
+          # Enable Laravel-specific tools
+          allowed_tools: "Bash(php artisan route:list),Bash(composer validate),Bash(php -l),Bash(./vendor/bin/phpunit --dry-run)"


### PR DESCRIPTION
## Summary
- Convert GitHub workflow from automatic PR triggers to manual workflow_dispatch
- Add input parameters for PR number and review focus options
- Include explicit instructions to NOT create pull requests automatically
- Ensure workflow only runs when manually triggered by maintainer

## Changes
- Modified `.github/workflows/claude-code-review.yml` to use `workflow_dispatch` trigger
- Added PR number input field (required)
- Added review focus selection with predefined options
- Updated workflow description and comments
- Removed automatic PR creation capabilities

## Test plan
- [x] Workflow file syntax is valid
- [x] Manual trigger parameters are properly configured
- [x] Instructions explicitly prevent automatic PR creation
- [x] Review focus options cover main areas (security, performance, architecture, Laravel practices)

🤖 Generated with [Claude Code](https://claude.ai/code)