### PR TITLE
🎨 Fix espacement uniforme des indicateurs de progression

### DIFF
--- a/resources/views/announcements/create.blade.php
+++ b/resources/views/announcements/create.blade.php
@@ -12,7 +12,7 @@
                 <!-- Indicateur de progression -->
                 <div class="mb-8">
                     <!-- Desktop: Horizontal layout -->
-                    <div class="hidden md:flex items-center justify-between mb-2">
+                    <div class="hidden md:flex items-center justify-center space-x-8 mb-2">
                         <div class="flex items-center">
                             <div id="step-1-indicator" class="w-10 h-10 bg-blue-600 text-white rounded-full flex items-center justify-center font-semibold">1</div>
                             <span class="ml-2 text-sm font-medium text-gray-900">Type d'annonce</span>

--- a/resources/views/country/announcements/create.blade.php
+++ b/resources/views/country/announcements/create.blade.php
@@ -25,7 +25,7 @@
                 <!-- Indicateur de progression -->
                 <div class="mb-8">
                     <!-- Desktop: Horizontal layout -->
-                    <div class="hidden md:flex items-center justify-between mb-2">
+                    <div class="hidden md:flex items-center justify-center space-x-8 mb-2">
                         <div class="flex items-center">
                             <div id="step-1-indicator" class="w-10 h-10 bg-blue-600 text-white rounded-full flex items-center justify-center font-semibold">1</div>
                             <span class="ml-2 text-sm font-medium text-gray-900">Type d'annonce</span>


### PR DESCRIPTION
## Summary
Correction de l'espacement des indicateurs de progression dans les formulaires de création d'annonces pour un rendu visuel plus harmonieux.

## Problème résolu
Les indicateurs de progression (1, 2, 3, 4, 5) n'étaient pas espacés uniformément à cause de l'utilisation de `justify-between`, créant un rendu visuel déséquilibré.

## Changements
- **Remplacement de `justify-between` par `justify-center space-x-8`**
- **Espacement uniforme** entre tous les indicateurs de progression
- **Amélioration visuelle** du stepper sur desktop

## Fichiers modifiés
- `resources/views/announcements/create.blade.php`
- `resources/views/country/announcements/create.blade.php`

## Test plan
- [ ] Vérifier l'espacement uniforme des indicateurs sur `/annonces/create`
- [ ] Vérifier l'espacement uniforme des indicateurs sur `/thailande/annonces/create`
- [ ] Tester sur différentes tailles d'écran desktop
- [ ] S'assurer que la version mobile reste inchangée

🤖 Generated with [Claude Code](https://claude.ai/code)