### PR TITLE
🔒 Fix CSP: Corriger erreurs Google Analytics en production

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -51,7 +51,7 @@ class SecurityHeaders
                    "style-src 'self' 'unsafe-inline' https://api.mapbox.com https://cdnjs.cloudflare.com https://cdn.tiny.cloud{$localSources}; " .
                    "img-src 'self' data: https:{$localSources}; " .
                    "font-src 'self' https://cdnjs.cloudflare.com{$localSources}; " .
-                   "connect-src 'self' https://api.mapbox.com https://events.mapbox.com https://api.bigdatacloud.net https://www.google-analytics.com https://analytics.google.com https://cdn.tiny.cloud{$localSources}; " .
+                   "connect-src 'self' https://api.mapbox.com https://events.mapbox.com https://api.bigdatacloud.net https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://cdn.tiny.cloud{$localSources}; " .
                    "worker-src 'self' blob:; " .
                    "frame-ancestors 'none'; " .
                    "base-uri 'self'; " .


### PR DESCRIPTION
## Summary

### 🐛 **Problème**
Google Analytics générait des erreurs CSP en production en essayant de se connecter à `region1.google-analytics.com`, domaine non autorisé dans la Content Security Policy.

### ✅ **Solution**
Ajout de `https://region1.google-analytics.com` dans la directive `connect-src` du middleware SecurityHeaders.

### 📝 **Modifications**
- **Fichier**: `app/Http/Middleware/SecurityHeaders.php`
- **Ligne modifiée**: connect-src pour la production
- **Ajout**: `https://region1.google-analytics.com`

### 🎯 **Impact**
- Élimination des erreurs CSP en console
- Google Analytics peut maintenant fonctionner correctement
- Aucun impact sur la sécurité (domaine officiel Google)

## Test plan

- [ ] Déployer en production
- [ ] Vérifier l'absence d'erreurs CSP dans la console
- [ ] Confirmer que Google Analytics fonctionne
- [ ] Valider que les autres services (Mapbox, etc.) fonctionnent toujours

🤖 Generated with [Claude Code](https://claude.ai/code)