### PR TITLE
🔧 Fix: Restaurer menu de partage desktop

### DIFF
--- a/public/js/share-component.js
+++ b/public/js/share-component.js
@@ -5,7 +5,14 @@
 class ShareComponent {
     constructor() {
         this.isWebShareSupported = 'share' in navigator;
+        this.isMobile = this.checkIfMobile();
         this.init();
+    }
+
+    checkIfMobile() {
+        // Détecter si c'est un appareil mobile
+        const userAgent = navigator.userAgent || navigator.vendor || window.opera;
+        return /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i.test(userAgent.toLowerCase());
     }
 
     init() {
@@ -23,15 +30,29 @@ class ShareComponent {
         const title = button.dataset.title || document.title;
         const text = button.dataset.text || '';
         const platform = button.dataset.platform;
+        const forceMenu = button.dataset.forceMenu === 'true';
 
-        // Si c'est un bouton de partage générique et que Web Share est supporté
-        if (!platform && this.isWebShareSupported) {
-            try {
-                await this.shareWithWebAPI(url, title, text);
+        // Si c'est un bouton de partage générique
+        if (!platform) {
+            // Si forceMenu est activé, toujours afficher le menu
+            if (forceMenu) {
+                this.showShareMenu(button, url, title, text);
                 return;
-            } catch (error) {
-                console.log('Web Share API non utilisée:', error);
-                // Fallback vers le menu de partage personnalisé
+            }
+            
+            // Utiliser Web Share API uniquement sur mobile ET si supporté
+            if (this.isMobile && this.isWebShareSupported) {
+                try {
+                    await this.shareWithWebAPI(url, title, text);
+                    return;
+                } catch (error) {
+                    console.log('Web Share API non utilisée:', error);
+                    // Fallback vers le menu de partage personnalisé
+                    this.showShareMenu(button, url, title, text);
+                    return;
+                }
+            } else {
+                // Sur desktop ou si Web Share n'est pas supporté, afficher le menu
                 this.showShareMenu(button, url, title, text);
                 return;
             }


### PR DESCRIPTION
## Summary

### 🐛 **Problème**
Le menu de partage personnalisé ne s'affichait plus sur desktop. Seule l'API Web Share native fonctionnait sur mobile, laissant les utilisateurs desktop sans option de partage.

### ✅ **Solution**
- **Détection mobile/desktop** : Ajout de `checkIfMobile()` pour identifier le type d'appareil
- **Logique conditionnelle** : Web Share API utilisée uniquement sur mobile
- **Menu forcé sur desktop** : Le menu personnalisé s'affiche toujours sur desktop
- **Option de forçage** : Possibilité d'utiliser `data-force-menu="true"` pour forcer le menu

### 📝 **Modifications techniques**
```javascript
// Avant : Web Share API tentait de fonctionner sur tous les navigateurs
if (\!platform && this.isWebShareSupported) { ... }

// Après : Web Share API uniquement sur mobile
if (this.isMobile && this.isWebShareSupported) { ... }
```

### 🎯 **Résultat**
- ✅ Desktop : Menu de partage avec toutes les options (Facebook, Twitter, etc.)
- ✅ Mobile : API native du système (comme Le Monde)
- ✅ Fallback : Menu personnalisé si l'API échoue
- ✅ Flexibilité : Option pour forcer le menu si nécessaire

## Test plan

- [ ] Tester sur desktop (Chrome, Firefox, Safari)
- [ ] Vérifier l'apparition du menu de partage
- [ ] Tester sur mobile (iOS, Android)
- [ ] Confirmer l'utilisation de l'API native
- [ ] Tester le fallback en cas d'échec
- [ ] Vérifier data-force-menu="true"

🤖 Generated with [Claude Code](https://claude.ai/code)