### PR TITLE
🔒 Fix: Sécurité Turnstile - Empêcher bypass de vérification

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -211,3 +211,27 @@
 .field-changed {
     animation: field-highlight 1s ease-out;
 }
+
+/* Styles pour les boutons sécurisés par Turnstile */
+.turnstile-pending {
+    @apply cursor-not-allowed opacity-60 transition-all duration-200;
+    pointer-events: auto !important; /* Permet de montrer le curseur not-allowed */
+}
+
+.turnstile-pending:hover {
+    @apply opacity-50;
+    transform: none !important; /* Annule les transformations hover des boutons normaux */
+}
+
+.turnstile-verified {
+    @apply cursor-pointer opacity-100 transition-all duration-200;
+}
+
+.turnstile-error {
+    @apply cursor-not-allowed opacity-60 bg-red-500 transition-all duration-200;
+}
+
+.turnstile-error:hover {
+    @apply opacity-50 bg-red-600;
+    transform: none !important;
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,3 +1,6 @@
 import './bootstrap';
 import $ from 'jquery';
 window.$ = window.jQuery = $;
+
+// Sécurité Turnstile - Protection contre les bypass de vérification
+import './turnstile-security';

--- a/resources/js/turnstile-security.js
+++ b/resources/js/turnstile-security.js
@@ -199,23 +199,13 @@ class TurnstileSecurityManager {
         state.submitButtons.forEach(button => {
             button.disabled = false;
             
-            // Restaurer le texte original ou utiliser un texte par défaut
-            const textSpan = button.querySelector('#submit-text, #create-text, #enrich-text, span:not(.hidden)');
-            const loadingSpan = button.querySelector('#submit-loading, #create-loading, #enrich-loading, .hidden');
-            
-            if (textSpan && loadingSpan) {
-                textSpan.classList.remove('hidden');
-                loadingSpan.classList.add('hidden');
-            } else {
-                // Fallback: restaurer le contenu HTML original si sauvegardé
-                if (button.dataset.originalContent) {
-                    button.innerHTML = button.dataset.originalContent;
-                } else {
-                    // Si pas de structure prédéfinie, ajouter une icône de succès
-                    const content = button.textContent.replace(/^[🔄❌]/, '✅');
-                    button.textContent = content;
-                }
+            // Sauvegarder le contenu original avant toute modification (si pas déjà fait)
+            if (!button.dataset.originalContent) {
+                button.dataset.originalContent = button.innerHTML;
             }
+            
+            // Restaurer complètement le contenu original
+            button.innerHTML = button.dataset.originalContent;
             
             // Ajouter une classe pour indiquer que la vérification est réussie
             button.classList.add('turnstile-verified');
@@ -237,19 +227,8 @@ class TurnstileSecurityManager {
                 button.dataset.originalContent = button.innerHTML;
             }
             
-            // Essayer de trouver les éléments de texte et loading spécifiques
-            const textSpan = button.querySelector('#submit-text, #create-text, #enrich-text');
-            const loadingSpan = button.querySelector('#submit-loading, #create-loading, #enrich-loading');
-            
-            if (textSpan && loadingSpan) {
-                // Structure avec spans séparés (comme dans les formulaires existants)
-                textSpan.classList.add('hidden');
-                loadingSpan.classList.remove('hidden');
-                loadingSpan.textContent = message;
-            } else {
-                // Fallback: remplacer tout le contenu
-                button.textContent = message;
-            }
+            // Remplacer simplement le contenu du bouton par le message
+            button.textContent = message;
             
             // Ajouter des classes CSS pour le style
             button.classList.add('turnstile-pending');

--- a/resources/js/turnstile-security.js
+++ b/resources/js/turnstile-security.js
@@ -1,0 +1,289 @@
+/**
+ * Turnstile Security Manager
+ * 
+ * Ce module sécurise automatiquement tous les formulaires avec Turnstile
+ * en empêchant leur soumission tant que la vérification n'est pas terminée.
+ */
+
+class TurnstileSecurityManager {
+    constructor() {
+        this.verifiedTokens = new Set();
+        this.formStates = new Map();
+        this.initializeOnDOMReady();
+    }
+
+    initializeOnDOMReady() {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', () => this.initialize());
+        } else {
+            this.initialize();
+        }
+    }
+
+    initialize() {
+        console.log('🔒 Initialisation du gestionnaire de sécurité Turnstile');
+        
+        // Trouver tous les formulaires avec Turnstile
+        const turnstileElements = document.querySelectorAll('.cf-turnstile');
+        
+        turnstileElements.forEach(turnstileEl => {
+            const form = turnstileEl.closest('form');
+            if (form) {
+                this.secureForm(form, turnstileEl);
+            }
+        });
+
+        // Configurer les callbacks globaux pour intercepter les réponses Turnstile
+        this.setupGlobalCallbacks();
+    }
+
+    secureForm(form, turnstileElement) {
+        const formId = form.id || `form_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+        if (!form.id) form.id = formId;
+
+        console.log(`🔒 Sécurisation du formulaire: ${formId}`);
+
+        // Trouver tous les boutons de soumission dans ce formulaire
+        const submitButtons = form.querySelectorAll('button[type="submit"], input[type="submit"]');
+        
+        // État initial: boutons désactivés
+        const initialState = {
+            isVerified: false,
+            turnstileLoaded: false,
+            submitButtons: Array.from(submitButtons),
+            originalCallbacks: {
+                success: turnstileElement.getAttribute('data-callback'),
+                error: turnstileElement.getAttribute('data-error-callback')
+            }
+        };
+
+        this.formStates.set(formId, initialState);
+
+        // Désactiver les boutons immédiatement
+        this.disableSubmitButtons(formId, '🔄 Vérification de sécurité...');
+
+        // Configurer les nouveaux callbacks
+        const uniqueCallbacks = this.generateUniqueCallbacks(formId);
+        turnstileElement.setAttribute('data-callback', uniqueCallbacks.success);
+        turnstileElement.setAttribute('data-error-callback', uniqueCallbacks.error);
+
+        // Intercepter la soumission du formulaire
+        form.addEventListener('submit', (e) => this.handleFormSubmit(e, formId));
+
+        // Détecter quand Turnstile est chargé
+        this.waitForTurnstileLoad(turnstileElement, formId);
+    }
+
+    generateUniqueCallbacks(formId) {
+        const successCallback = `turnstileSuccess_${formId.replace(/[^a-zA-Z0-9]/g, '_')}`;
+        const errorCallback = `turnstileError_${formId.replace(/[^a-zA-Z0-9]/g, '_')}`;
+
+        // Créer les fonctions callback dans window
+        window[successCallback] = (token) => this.handleTurnstileSuccess(formId, token);
+        window[errorCallback] = (error) => this.handleTurnstileError(formId, error);
+
+        return {
+            success: successCallback,
+            error: errorCallback
+        };
+    }
+
+    waitForTurnstileLoad(turnstileElement, formId) {
+        const checkInterval = setInterval(() => {
+            // Vérifier si Turnstile est chargé (le widget devient visible)
+            const widget = turnstileElement.querySelector('iframe');
+            if (widget) {
+                console.log(`✅ Turnstile chargé pour ${formId}`);
+                const state = this.formStates.get(formId);
+                state.turnstileLoaded = true;
+                this.updateButtonState(formId);
+                clearInterval(checkInterval);
+            }
+        }, 100);
+
+        // Timeout après 10 secondes
+        setTimeout(() => {
+            clearInterval(checkInterval);
+            const state = this.formStates.get(formId);
+            if (!state.turnstileLoaded) {
+                console.warn(`⚠️ Timeout du chargement Turnstile pour ${formId}`);
+                this.disableSubmitButtons(formId, '❌ Erreur de sécurité - Rechargez la page');
+            }
+        }, 10000);
+    }
+
+    handleTurnstileSuccess(formId, token) {
+        console.log(`✅ Turnstile vérifié avec succès pour ${formId}:`, token);
+        
+        const state = this.formStates.get(formId);
+        state.isVerified = true;
+        this.verifiedTokens.add(token);
+
+        // Appeler le callback original s'il existe
+        if (state.originalCallbacks.success && window[state.originalCallbacks.success]) {
+            window[state.originalCallbacks.success](token);
+        }
+
+        this.updateButtonState(formId);
+    }
+
+    handleTurnstileError(formId, error) {
+        console.error(`❌ Erreur Turnstile pour ${formId}:`, error);
+        
+        const state = this.formStates.get(formId);
+        state.isVerified = false;
+
+        // Appeler le callback original s'il existe
+        if (state.originalCallbacks.error && window[state.originalCallbacks.error]) {
+            window[state.originalCallbacks.error](error);
+        }
+
+        this.disableSubmitButtons(formId, '❌ Erreur de vérification - Rechargez la page');
+    }
+
+    updateButtonState(formId) {
+        const state = this.formStates.get(formId);
+        
+        if (state.isVerified && state.turnstileLoaded) {
+            this.enableSubmitButtons(formId);
+        } else if (state.turnstileLoaded && !state.isVerified) {
+            this.disableSubmitButtons(formId, '🔄 En attente de vérification...');
+        }
+    }
+
+    enableSubmitButtons(formId) {
+        const state = this.formStates.get(formId);
+        if (!state) return;
+
+        state.submitButtons.forEach(button => {
+            button.disabled = false;
+            
+            // Restaurer le texte original ou utiliser un texte par défaut
+            const textSpan = button.querySelector('#submit-text, #create-text, #enrich-text, span:not(.hidden)');
+            const loadingSpan = button.querySelector('#submit-loading, #create-loading, #enrich-loading, .hidden');
+            
+            if (textSpan && loadingSpan) {
+                textSpan.classList.remove('hidden');
+                loadingSpan.classList.add('hidden');
+            } else {
+                // Fallback: restaurer le contenu HTML original si sauvegardé
+                if (button.dataset.originalContent) {
+                    button.innerHTML = button.dataset.originalContent;
+                } else {
+                    // Si pas de structure prédéfinie, ajouter une icône de succès
+                    const content = button.textContent.replace(/^[🔄❌]/, '✅');
+                    button.textContent = content;
+                }
+            }
+            
+            // Ajouter une classe pour indiquer que la vérification est réussie
+            button.classList.add('turnstile-verified');
+            button.classList.remove('turnstile-pending', 'turnstile-error');
+        });
+
+        console.log(`✅ Boutons de soumission activés pour ${formId}`);
+    }
+
+    disableSubmitButtons(formId, message = '🔄 Vérification en cours...') {
+        const state = this.formStates.get(formId);
+        if (!state) return;
+
+        state.submitButtons.forEach(button => {
+            button.disabled = true;
+            
+            // Sauvegarder le contenu original s'il n'est pas déjà sauvegardé
+            if (!button.dataset.originalContent) {
+                button.dataset.originalContent = button.innerHTML;
+            }
+            
+            // Essayer de trouver les éléments de texte et loading spécifiques
+            const textSpan = button.querySelector('#submit-text, #create-text, #enrich-text');
+            const loadingSpan = button.querySelector('#submit-loading, #create-loading, #enrich-loading');
+            
+            if (textSpan && loadingSpan) {
+                // Structure avec spans séparés (comme dans les formulaires existants)
+                textSpan.classList.add('hidden');
+                loadingSpan.classList.remove('hidden');
+                loadingSpan.textContent = message;
+            } else {
+                // Fallback: remplacer tout le contenu
+                button.textContent = message;
+            }
+            
+            // Ajouter des classes CSS pour le style
+            button.classList.add('turnstile-pending');
+            button.classList.remove('turnstile-verified', 'turnstile-error');
+        });
+
+        console.log(`🔒 Boutons de soumission désactivés pour ${formId}: ${message}`);
+    }
+
+    handleFormSubmit(event, formId) {
+        const state = this.formStates.get(formId);
+        
+        if (!state || !state.isVerified) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            
+            console.warn(`🚫 Soumission bloquée pour ${formId} - Turnstile non vérifié`);
+            
+            // Afficher un message d'erreur à l'utilisateur
+            this.showUserError('Veuillez patienter pendant la vérification de sécurité...');
+            
+            return false;
+        }
+
+        console.log(`✅ Soumission autorisée pour ${formId} - Turnstile vérifié`);
+        return true;
+    }
+
+    showUserError(message) {
+        // Créer ou réutiliser une alerte
+        let alert = document.getElementById('turnstile-security-alert');
+        if (!alert) {
+            alert = document.createElement('div');
+            alert.id = 'turnstile-security-alert';
+            alert.className = 'fixed top-4 right-4 bg-red-500 text-white px-6 py-3 rounded-lg shadow-lg z-50 flex items-center';
+            document.body.appendChild(alert);
+        }
+
+        alert.innerHTML = `
+            <span class="mr-2">🔐</span>
+            <span>${message}</span>
+        `;
+        
+        alert.style.display = 'flex';
+        
+        // Auto-masquer après 4 secondes
+        setTimeout(() => {
+            if (alert.parentNode) {
+                alert.style.display = 'none';
+            }
+        }, 4000);
+    }
+
+    setupGlobalCallbacks() {
+        // Callback de secours pour détecter les réussites Turnstile non interceptées
+        const originalOnload = window.onTurnstileLoad;
+        window.onTurnstileLoad = () => {
+            console.log('🔄 Détection du chargement global de Turnstile');
+            if (originalOnload) originalOnload();
+        };
+    }
+
+    // Méthode publique pour déboguer
+    getFormStates() {
+        return Object.fromEntries(this.formStates);
+    }
+}
+
+// Initialiser automatiquement
+const turnstileSecurity = new TurnstileSecurityManager();
+
+// Exporter pour utilisation globale
+window.TurnstileSecurityManager = turnstileSecurity;
+
+// Debug en développement
+if (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') {
+    window.debugTurnstile = () => turnstileSecurity.getFormStates();
+}

--- a/resources/js/turnstile-security.js
+++ b/resources/js/turnstile-security.js
@@ -86,49 +86,42 @@ class TurnstileSecurityManager {
         const originalSuccessCallback = state.originalCallbacks.success;
         const originalErrorCallback = state.originalCallbacks.error;
 
-        // Approche simplifiée : toujours encapsuler les callbacks existants
-        if (originalSuccessCallback) {
+        // Approche simple : encapsuler les callbacks existants en conservant leur logique
+        if (originalSuccessCallback && window[originalSuccessCallback]) {
             console.log(`🔄 Encapsulation du callback existant: ${originalSuccessCallback}`);
             
-            // Créer un nouvel ID unique pour le wrapper
-            const wrappedCallbackName = `${originalSuccessCallback}_wrapped_${Date.now()}`;
+            // Sauvegarder l'original
+            const originalFunction = window[originalSuccessCallback];
             
-            // Sauvegarder l'original avec un nom unique
-            window[wrappedCallbackName] = window[originalSuccessCallback];
-            
-            // Remplacer par notre wrapper qui appelle notre gestionnaire ET l'original
+            // Remplacer par notre wrapper
             window[originalSuccessCallback] = (token) => {
                 console.log(`🔓 Callback Turnstile success intercepté pour ${formId}`, token);
                 
-                // Notre gestionnaire en premier pour débloquer le bouton
-                this.handleTurnstileSuccess(formId, token);
-                
-                // Puis l'original si il existait
-                if (window[wrappedCallbackName] && typeof window[wrappedCallbackName] === 'function') {
-                    console.log(`🔄 Appel du callback original: ${wrappedCallbackName}`);
-                    window[wrappedCallbackName](token);
+                // Exécuter l'original en premier (pour maintenir la logique métier)
+                if (originalFunction && typeof originalFunction === 'function') {
+                    originalFunction(token);
                 }
+                
+                // Puis notre gestionnaire pour débloquer le bouton
+                this.handleTurnstileSuccess(formId, token);
             };
         }
 
-        if (originalErrorCallback) {
+        if (originalErrorCallback && window[originalErrorCallback]) {
             console.log(`🔄 Encapsulation du callback erreur existant: ${originalErrorCallback}`);
             
-            // Créer un nouvel ID unique pour le wrapper
-            const wrappedErrorCallbackName = `${originalErrorCallback}_wrapped_${Date.now()}`;
-            
-            // Sauvegarder l'original avec un nom unique
-            window[wrappedErrorCallbackName] = window[originalErrorCallback];
+            const originalErrorFunction = window[originalErrorCallback];
             
             window[originalErrorCallback] = (error) => {
                 console.log(`❌ Callback Turnstile error intercepté pour ${formId}`, error);
                 
-                this.handleTurnstileError(formId, error);
-                
-                if (window[wrappedErrorCallbackName] && typeof window[wrappedErrorCallbackName] === 'function') {
-                    console.log(`🔄 Appel du callback erreur original: ${wrappedErrorCallbackName}`);
-                    window[wrappedErrorCallbackName](error);
+                // Exécuter l'original en premier
+                if (originalErrorFunction && typeof originalErrorFunction === 'function') {
+                    originalErrorFunction(error);
                 }
+                
+                // Puis notre gestionnaire
+                this.handleTurnstileError(formId, error);
             };
         }
 

--- a/resources/js/turnstile-security.js
+++ b/resources/js/turnstile-security.js
@@ -207,6 +207,8 @@ class TurnstileSecurityManager {
             // Restaurer complètement le contenu original
             button.innerHTML = button.dataset.originalContent;
             
+            // Les styles sont maintenant gérés par les classes CSS
+            
             // Ajouter une classe pour indiquer que la vérification est réussie
             button.classList.add('turnstile-verified');
             button.classList.remove('turnstile-pending', 'turnstile-error');
@@ -230,7 +232,7 @@ class TurnstileSecurityManager {
             // Remplacer simplement le contenu du bouton par le message
             button.textContent = message;
             
-            // Ajouter des classes CSS pour le style
+            // Ajouter des classes CSS pour le style et le curseur
             button.classList.add('turnstile-pending');
             button.classList.remove('turnstile-verified', 'turnstile-error');
         });

--- a/resources/views/emails/contact.blade.php
+++ b/resources/views/emails/contact.blade.php
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Nouveau message de contact - Sekaijin</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 600px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #f4f4f4;
+        }
+        .container {
+            background-color: white;
+            padding: 30px;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        .header {
+            background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+            color: white;
+            padding: 20px;
+            border-radius: 8px;
+            margin-bottom: 30px;
+            text-align: center;
+        }
+        .field {
+            margin-bottom: 20px;
+            padding: 15px;
+            background-color: #f8f9fa;
+            border-radius: 5px;
+            border-left: 4px solid #3b82f6;
+        }
+        .field-label {
+            font-weight: bold;
+            color: #3b82f6;
+            margin-bottom: 5px;
+        }
+        .field-value {
+            color: #333;
+            word-break: break-word;
+        }
+        .message-content {
+            background-color: #fff;
+            padding: 20px;
+            border: 1px solid #e5e7eb;
+            border-radius: 5px;
+            white-space: pre-wrap;
+            font-family: Georgia, serif;
+            line-height: 1.8;
+        }
+        .footer {
+            margin-top: 30px;
+            text-align: center;
+            font-size: 12px;
+            color: #6b7280;
+            border-top: 1px solid #e5e7eb;
+            padding-top: 20px;
+        }
+        .footer a {
+            color: #3b82f6;
+            text-decoration: none;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>🌍 Nouveau message de contact</h1>
+            <p>Un utilisateur a envoyé un message via le formulaire de contact de Sekaijin</p>
+        </div>
+
+        <div class="field">
+            <div class="field-label">👤 Nom :</div>
+            <div class="field-value">{{ $contactName }}</div>
+        </div>
+
+        <div class="field">
+            <div class="field-label">📧 Email :</div>
+            <div class="field-value">{{ $contactEmail }}</div>
+        </div>
+
+        <div class="field">
+            <div class="field-label">📋 Sujet :</div>
+            <div class="field-value">{{ $contactSubject }}</div>
+        </div>
+
+        <div class="field">
+            <div class="field-label">💬 Message :</div>
+            <div class="message-content">{{ $contactMessage }}</div>
+        </div>
+
+        <div class="footer">
+            <p>
+                📨 Email envoyé automatiquement depuis le site <a href="{{ url('/') }}">Sekaijin</a><br>
+                🔒 Cet email provient d'un formulaire sécurisé par Cloudflare Turnstile<br>
+                🕒 Reçu le {{ date('d/m/Y à H:i') }}
+            </p>
+            
+            <p style="margin-top: 15px; font-size: 11px;">
+                💡 Pour répondre directement à l'utilisateur, utilisez la fonction "Répondre" de votre client email.<br>
+                L'adresse de réponse est automatiquement configurée sur : {{ $contactEmail }}
+            </p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Problème critique résolu

❌ **Bypass de sécurité identifié** : Les utilisateurs pouvaient cliquer sur les boutons de connexion/inscription avant que Cloudflare Turnstile termine sa vérification.

## Solution implémentée

✅ **TurnstileSecurityManager** - Gestionnaire automatique de sécurité :

### Fonctionnalités
- 🔒 **Blocage automatique** : Tous les boutons de soumission sont désactivés par défaut
- 🔄 **Feedback visuel** : Indicateurs de progression pendant la vérification  
- 🛡️ **Protection formulaires** : Intercepte toutes les soumissions avant vérification
- ⚡ **Auto-détection** : Trouve et sécurise automatiquement tous les formulaires avec Turnstile
- 🎯 **Callbacks intelligents** : Remplace et encapsule les callbacks existants

### Sécurité renforcée
- Empêche la soumission si Turnstile n'est pas vérifié
- Gère les timeouts et erreurs de chargement
- Affiche des messages d'erreur utilisateur appropriés
- Compatible avec tous les formulaires existants (login, register, contact)

### Intégration transparente
- Import automatique dans `resources/js/app.js`
- Compilation via Vite pour performance optimale
- Aucune modification des templates existants requise
- Préserve les callbacks utilisateur existants

## Test plan
- [x] Vérifier que les boutons sont désactivés au chargement
- [x] Confirmer que la soumission est bloquée avant vérification Turnstile
- [x] Tester l'activation des boutons après vérification réussie
- [x] Valider le feedback visuel pendant la vérification
- [x] Vérifier la compatibilité avec login, register et contact

🤖 Generated with [Claude Code](https://claude.ai/code)