### PR TITLE
🐛 Fix: Resolve Turnstile return type error in AuthController

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -9,7 +9,7 @@ use App\Services\TurnstileService;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
+use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -9,12 +9,12 @@ use App\Services\TurnstileService;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Facades\Validator;
+use Symfony\Component\HttpFoundation\Response;
 
 class AuthController extends Controller
 {


### PR DESCRIPTION
## Summary
- Fix TypeError in production where `verifyTurnstileForRequest()` returns JsonResponse but expects Response
- Change import from `Illuminate\Http\Response` to `Symfony\Component\HttpFoundation\Response` to support both return types

## Error Fixed
```
App\Http\Controllers\AuthController::verifyTurnstileForRequest(): Return value must be of type ?Illuminate\Http\Response, Illuminate\Http\JsonResponse returned
```

## Solution
The method signature declared the return type as `?Response` but was returning `JsonResponse` for AJAX requests. Since `JsonResponse` extends `Response`, using the Symfony base class allows both types to be returned without type errors.

🤖 Generated with [Claude Code](https://claude.ai/code)