### PR TITLE
🐛 Fix: Add missing Country model import in AuthController

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Mail\WelcomeEmail;
+use App\Models\Country;
 use App\Models\User;
 use App\Services\EmailBlacklistService;
 use App\Services\TurnstileService;


### PR DESCRIPTION
## Summary
- Fix "Class not found" error during user registration
- Add missing `use App\Models\Country;` import statement

## Error Fixed
```
Class "App\Http\Controllers\Country" not found at /app/Http/Controllers/AuthController.php:108
```

## Solution
The AuthController was using the Country model without importing it. Added the proper import statement to resolve the namespace issue.

🤖 Generated with [Claude Code](https://claude.ai/code)